### PR TITLE
Add compatibility with --enable-frozen-string-literal

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,10 +32,10 @@ jobs:
     environment:
       CODECLIMATE_REPO_TOKEN: 230dc861ec831b64dc4818a2002de07fbd2a413cc460385eb05958564eb70687
       BUNDLE_GEMFILE: gemfiles/Gemfile
+      RUBYOPT: "--enable-frozen-string-literal"
     steps:
       - rspec:
         rvm: << parameters.version >>
-        #- run: "bundle exec codeclimate-test-reporter"
   build-rails:
     parameters: 
       version:
@@ -46,6 +46,7 @@ jobs:
     environment:
       RAILS_ENV: test
       BUNDLE_GEMFILE: gemfiles/Gemfile.rails-6.1.x
+      RUBYOPT: "--enable-frozen-string-literal"
     steps:
       - rspec:
         rvm: << parameters.version >>

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,11 +9,9 @@ GEM
     benchmark-ips (2.12.0)
     benchmark-memory (0.2.0)
       memory_profiler (~> 1)
-    codeclimate-test-reporter (1.0.9)
-      simplecov (<= 0.13)
     coderay (1.1.2)
     diff-lcs (1.2.5)
-    docile (1.1.5)
+    docile (1.4.0)
     json (2.3.1)
     memory_profiler (1.0.1)
     method_source (0.9.0)
@@ -37,11 +35,12 @@ GEM
     rspec-expectations (2.14.5)
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.14.6)
-    simplecov (0.13.0)
-      docile (~> 1.1.0)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.2)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
 
 PLATFORMS
   ruby
@@ -49,7 +48,6 @@ PLATFORMS
 DEPENDENCIES
   benchmark-ips
   benchmark-memory
-  codeclimate-test-reporter (~> 1.0.9)
   json (= 2.3.1)
   nokogiri (~> 1.15)
   phonelib!

--- a/lib/phonelib/phone.rb
+++ b/lib/phonelib/phone.rb
@@ -24,7 +24,7 @@ module Phonelib
     # @return [Phonelib::Phone] parsed phone instance
     def initialize(phone, country = nil)
       @original, @extension = separate_extension(phone.to_s)
-      @extension.gsub!(/[^0-9]/, '') if @extension
+      @extension = @extension.gsub(/[^0-9]/, '') if @extension
 
       if sanitized.empty?
         @data = {}

--- a/lib/phonelib/phone_formatter.rb
+++ b/lib/phonelib/phone_formatter.rb
@@ -159,7 +159,7 @@ module Phonelib
              data[Core::NATIONAL_PREFIX_RULE] || '$1'
 
       # change rule's constants to values
-      rule.gsub!(/(\$NP|\$FG)/, '$NP' => prefix, '$FG' => '$1')
+      rule = rule.gsub(/(\$NP|\$FG)/, '$NP' => prefix, '$FG' => '$1')
 
       # add space to format groups, change first group to rule,
       format_string = format[:format].gsub(/(\d)\$/, '\\1 $')

--- a/phonelib.gemspec
+++ b/phonelib.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |s|
   end
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rspec', '= 2.14.1'
-  s.add_development_dependency 'codeclimate-test-reporter', '~> 1.0.9'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'benchmark-ips'
   s.add_development_dependency 'benchmark-memory'

--- a/spec/phonelib_spec.rb
+++ b/spec/phonelib_spec.rb
@@ -1,8 +1,5 @@
 require 'phonelib'
 
-# deprecated code climate
-#require 'codeclimate-test-reporter'
-#CodeClimate::TestReporter.start
 require 'simplecov'
 SimpleCov.start
 


### PR DESCRIPTION
Since Ruby 2.7, Ruby can be run with --enable-frozen-string-literal to improve memory efficiency and avoid mistakes.

Ruby 3.4 is also now moving towards a world where string literals are frozen by default:
https://www.ruby-lang.org/en/news/2024/05/16/ruby-3-4-0-preview1-released/

This commit handles errors that arise when Phonelib is run with this feature enabled. It add the option to the CI configuration via an environment variable to ensure that regressions are not introduced.

In doing so, I needed to upgrade the simplecov gem to at least 0.15.0, because that’s the first version that is compatible with --enable-frozen-string-literal:
https://github.com/simplecov-ruby/simplecov/blob/main/CHANGELOG.old.md#0150-2017-08-14-changes

This upgrade was prevented by the codeclimate-test-reporter gem, which locks simplecov to <= 0.13.

However, I found that codeclimate-test-reporter is deprecated (https://github.com/codeclimate/ruby-test-reporter) and also that the uses of it in this codebase had already been commented out. Therefore I have removed it entirely, enabling the upgrade to simplecov.